### PR TITLE
fix for latest jsx

### DIFF
--- a/src/socketio_data_protocol.erl
+++ b/src/socketio_data_protocol.erl
@@ -51,10 +51,10 @@ message(Id, EndPoint, Msg) when is_binary(Id) ->
 
 json(Id, EndPoint, Msg) when is_integer(Id) ->
     IdBin = binary:list_to_bin(integer_to_list(Id)),
-    JsonBin = jsx:term_to_json(Msg),
+    JsonBin = jsx:encode(Msg),
     <<"4:", IdBin/binary, ":", EndPoint/binary, ":", JsonBin/binary>>;
 json(Id, EndPoint, Msg) when is_binary(Id) ->
-    JsonBin = jsx:term_to_json(Msg),
+    JsonBin = jsx:encode(Msg),
     <<"4:", Id/binary, ":", EndPoint/binary, ":", JsonBin/binary>>.
 
 error(EndPoint, Reason) ->
@@ -114,7 +114,7 @@ decode_packet(<<"3:", Rest/binary>>) ->
 decode_packet(<<"4:", Rest/binary>>) ->
     {Id, R1} = id(Rest),
     {EndPoint, Data} = endpoint(R1),
-    {json, Id, EndPoint, jsx:json_to_term(Data)};
+    {json, Id, EndPoint, jsx:decode(Data)};
 decode_packet(<<"7::", Rest/binary>>) ->
     {EndPoint, R1} = endpoint(Rest),
     case reason(R1) of


### PR DESCRIPTION
Changed function name for latest jsx.

* ```jsx:term_to_json/1``` -> ```jsx:encode/1```
* ```jsx:json_to_term/1``` ->  ```jsx:decode/1```